### PR TITLE
Zookeeper 3.6 requires snappy classes to bootstrap

### DIFF
--- a/kyuubi-shaded-zookeeper-parent/kyuubi-shaded-zookeeper-36/pom.xml
+++ b/kyuubi-shaded-zookeeper-parent/kyuubi-shaded-zookeeper-36/pom.xml
@@ -34,6 +34,7 @@ under the License.
         <zookeeper.version>3.6.4</zookeeper.version>
         <curator.version>5.4.0</curator.version>
         <netty.version>4.1.91.Final</netty.version>
+        <snappy.version>1.1.8.4</snappy.version>
     </properties>
 
     <dependencyManagement>
@@ -146,6 +147,12 @@ under the License.
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- required by kyuubi embedded Zookeeper server to bootstrap -->
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/kyuubi-shaded-zookeeper-parent/kyuubi-shaded-zookeeper-36/src/main/resources/META-INF/NOTICE
+++ b/kyuubi-shaded-zookeeper-parent/kyuubi-shaded-zookeeper-36/src/main/resources/META-INF/NOTICE
@@ -22,3 +22,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.curator:curator-recipes:5.4.0
 - org.apache.zookeeper:zookeeper-jute:3.6.4
 - org.apache.zookeeper:zookeeper:3.6.4
+- org.xerial.snappy:xerial-java:1.1.8.4

--- a/kyuubi-shaded-zookeeper-parent/pom.xml
+++ b/kyuubi-shaded-zookeeper-parent/pom.xml
@@ -78,6 +78,10 @@ under the License.
                                     <pattern>com.google</pattern>
                                     <shadedPattern>${shading.prefix}.google</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.xerial.snappy</pattern>
+                                    <shadedPattern>${shading.prefix}.snappy</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix the following error in Zookeeper server bootstrap

```
A needed class was not found. This could be due to an error in your runpath. Missing class: org/xerial/snappy/SnappyInputStream
java.lang.NoClassDefFoundError: org/xerial/snappy/SnappyInputStream
	at org.apache.kyuubi.shaded.zookeeper.server.persistence.Util.makeSnapshotName(Util.java:97)
	at org.apache.kyuubi.shaded.zookeeper.server.persistence.FileTxnSnapLog.save(FileTxnSnapLog.java:478)
	at org.apache.kyuubi.shaded.zookeeper.server.persistence.FileTxnSnapLog.restore(FileTxnSnapLog.java:300)
	at org.apache.kyuubi.shaded.zookeeper.server.ZKDatabase.loadDataBase(ZKDatabase.java:285)
	at org.apache.kyuubi.shaded.zookeeper.server.ZooKeeperServer.loadData(ZooKeeperServer.java:505)
	at org.apache.kyuubi.shaded.zookeeper.server.ZooKeeperServer.startdata(ZooKeeperServer.java:680)
	at org.apache.kyuubi.shaded.zookeeper.server.NIOServerCnxnFactory.startup(NIOServerCnxnFactory.java:758)
	at org.apache.kyuubi.shaded.zookeeper.server.ServerCnxnFactory.startup(ServerCnxnFactory.java:130)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeper.start(EmbeddedZookeeper.scala:58)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.$anonfun$new$1(EmbeddedZookeeperSuite.scala:39)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
	at org.apache.kyuubi.KyuubiFunSuite.withFixture(KyuubiFunSuite.scala:63)
	at org.apache.kyuubi.KyuubiFunSuite.withFixture$(KyuubiFunSuite.scala:57)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.withFixture(EmbeddedZookeeperSuite.scala:27)
	at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.org$scalatest$BeforeAndAfterEach$$super$runTest(EmbeddedZookeeperSuite.scala:27)
	at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
	at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.runTest(EmbeddedZookeeperSuite.scala:27)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
	at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
	at org.scalatest.Suite.run(Suite.scala:1114)
	at org.scalatest.Suite.run$(Suite.scala:1096)
	at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
	at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
	at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.org$scalatest$BeforeAndAfterAll$$super$run(EmbeddedZookeeperSuite.scala:27)
	at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
	at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
	at org.apache.kyuubi.zookeeper.EmbeddedZookeeperSuite.run(EmbeddedZookeeperSuite.scala:27)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
	at org.scalatest.tools.Runner$.run(Runner.scala:798)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2or3(ScalaTestRunner.java:43)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:26)
Caused by: java.lang.ClassNotFoundException: org.xerial.snappy.SnappyInputStream
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	... 62 more
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
