### PR TITLE
Introduce `kyuubi-shaded-hive-service-rpc`

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -21,6 +21,8 @@
 **/*.log
 **/*.md
 **/*.iml
+**/*.tmp
+**/*.temp
 **/target/**
 **/out/**
 **/licenses/LICENSE*

--- a/kyuubi-shaded-hive-service-rpc/pom.xml
+++ b/kyuubi-shaded-hive-service-rpc/pom.xml
@@ -28,14 +28,50 @@ under the License.
         <version>0.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>kyuubi-shaded-zookeeper-parent</artifactId>
-    <packaging>pom</packaging>
-    <name>kyuubi-shaded-zookeeper-parent</name>
+    <artifactId>kyuubi-shaded-hive-service-rpc</artifactId>
+    <name>kyuubi-shaded-hive-service-rpc</name>
 
-    <modules>
-        <module>kyuubi-shaded-zookeeper-34</module>
-        <module>kyuubi-shaded-zookeeper-36</module>
-    </modules>
+    <properties>
+        <hive.service.rpc.version>3.1.3</hive.service.rpc.version>
+        <fb303.version>0.9.3</fb303.version>
+        <thrift.version>0.9.3-1</thrift.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-service-rpc</artifactId>
+            <version>${hive.service.rpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libfb303</artifactId>
+            <version>${fb303.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>libthrift</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${thrift.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -78,28 +114,25 @@ under the License.
                             </filters>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.zookeeper</pattern>
-                                    <shadedPattern>${shading.prefix}.zookeeper</shadedPattern>
+                                    <pattern>org.apache.hive.service.rpc.thrift</pattern>
+                                    <shadedPattern>${shading.prefix}.org.apache.hive.service.rpc.thrift</shadedPattern>
+                                    <includes>
+                                        <include>org.apache.hive.service.rpc.thrift.**</include>
+                                    </includes>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.jute</pattern>
-                                    <shadedPattern>${shading.prefix}.jute</shadedPattern>
+                                    <pattern>com.facebook.fb303</pattern>
+                                    <shadedPattern>${shading.prefix}.com.facebook.fb303</shadedPattern>
+                                    <includes>
+                                        <include>com.facebook.fb303.**</include>
+                                    </includes>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.codahale.metrics</pattern>
-                                    <shadedPattern>${shading.prefix}.metrics</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.curator</pattern>
-                                    <shadedPattern>${shading.prefix}.curator</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>${shading.prefix}.google</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.xerial.snappy</pattern>
-                                    <shadedPattern>${shading.prefix}.snappy</shadedPattern>
+                                    <pattern>org.apache.thrift</pattern>
+                                    <shadedPattern>${shading.prefix}.org.apache.thrift</shadedPattern>
+                                    <includes>
+                                        <include>org.apache.thrift.**</include>
+                                    </includes>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/kyuubi-shaded-hive-service-rpc/pom.xml
+++ b/kyuubi-shaded-hive-service-rpc/pom.xml
@@ -115,21 +115,21 @@ under the License.
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.hive.service.rpc.thrift</pattern>
-                                    <shadedPattern>${shading.prefix}.org.apache.hive.service.rpc.thrift</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.hive.service.rpc.thrift</shadedPattern>
                                     <includes>
                                         <include>org.apache.hive.service.rpc.thrift.**</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.facebook.fb303</pattern>
-                                    <shadedPattern>${shading.prefix}.com.facebook.fb303</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.fb303</shadedPattern>
                                     <includes>
                                         <include>com.facebook.fb303.**</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.thrift</pattern>
-                                    <shadedPattern>${shading.prefix}.org.apache.thrift</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.thrift</shadedPattern>
                                     <includes>
                                         <include>org.apache.thrift.**</include>
                                     </includes>

--- a/kyuubi-shaded-hive-service-rpc/src/main/resources/META-INF/NOTICE
+++ b/kyuubi-shaded-hive-service-rpc/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,11 @@
+kyuubi-shaded-hive-service-rpc
+Copyright 2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.hive:hive-service-rpc:3.1.3
+- org.apache.thrift:libfb303:0.9.3
+- org.apache.thrift:libthrift:0.9.3-1

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 
     <modules>
         <module>kyuubi-shaded-force-shading</module>
+        <module>kyuubi-shaded-hive-service-rpc</module>
         <module>kyuubi-shaded-zookeeper-parent</module>
     </modules>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR aims to introduce a new pre-shaded module `kyuubi-shaded-hive-service-rpc` for Kyuubi project, which contains

- org.apache.hive:hive-service-rpc:3.1.3
- org.apache.thrift:libfb303:0.9.3
- org.apache.thrift:libthrift:0.9.3-1

Kyuubi uses Hive Service RPC (a thrift-based protocol) as the internal RPC protocol, currently, we do shading during each engine jar packaging, it works well for most engines except for Hive engines, such shading would corrupt the Hive method invocation because the same package name, i.e.

```
import org.apache.hive.service.rpc.thrift.TGetInfoReq

def method(
  // this is part of Kyuubi server-engine internal RPC
  getInfoReq: TGetInfoReq) {
  // it's a Hive internal method invocation
  hiveObj.hiveMethod(getInfoReq)
}
```

if we switch to the pre-shaded `kyuubi-shaded-hive-service-rpc`, it could be solved as
```
import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TGetInfoReq
import org.apache.hive.service.rpc.thrift.{TGetInfoReq => HiveTGetInfoReq}

def method(
  // this is part of Kyuubi server-engine internal RPC
  getInfoReq: TGetInfoReq) {
  // it's a Hive internal method invocation
  val hiveGetInfoReq: HiveTGetInfoReq = HiveRpcUtils.asHive(getInfoReq)
  hiveObj.hiveMethod(hiveGetInfoReq)
}
```

In addition, `kyuubi-shaded-hive-service-rpc` also shades the Thrift runtime classes. The upcoming Hive 2.3.10, 3.2.0, 4.0.0 upgrade Thrift to 0.14+, has known incompatible changes with the current 0.9.3, pre-shaded classes also resolve the class conflicts.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
