### PR TITLE
[KYUUBI-SHADED #28] Step 1/2: Overwrite SnapStream to remove deps of snappy in ZK client 3.6

### DIFF
--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/pom.xml
@@ -36,7 +36,6 @@ under the License.
         <zookeeper.version>3.6.4</zookeeper.version>
         <curator.version>5.4.0</curator.version>
         <netty.version>4.1.91.Final</netty.version>
-        <snappy.version>1.1.8.4</snappy.version>
     </properties>
 
     <dependencyManagement>
@@ -160,12 +159,6 @@ under the License.
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <!-- required by kyuubi embedded Zookeeper server to bootstrap -->
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/src/main/java/org/apache/zookeeper/server/persistence/SnapStream.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.zip.Adler32;
 import java.util.zip.CheckedInputStream;
 import java.util.zip.CheckedOutputStream;
@@ -40,9 +39,6 @@ import org.apache.jute.OutputArchive;
 import org.apache.zookeeper.common.AtomicFileOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xerial.snappy.SnappyCodec;
-import org.xerial.snappy.SnappyInputStream;
-import org.xerial.snappy.SnappyOutputStream;
 
 /** Represent the Stream used in serialize and deserialize the Snapshot. */
 public class SnapStream {
@@ -106,8 +102,8 @@ public class SnapStream {
         is = new GZIPInputStream(fis);
         break;
       case SNAPPY:
-        is = new SnappyInputStream(fis);
-        break;
+        throw new UnsupportedOperationException(
+            "[KYUUBI-SHADED #28] " + ZOOKEEPER_SHAPSHOT_STREAM_MODE + " does not support snappy");
       case CHECKED:
       default:
         is = new BufferedInputStream(fis);
@@ -131,8 +127,8 @@ public class SnapStream {
         os = new GZIPOutputStream(fos);
         break;
       case SNAPPY:
-        os = new SnappyOutputStream(fos);
-        break;
+        throw new UnsupportedOperationException(
+            "[KYUUBI-SHADED #28] " + ZOOKEEPER_SHAPSHOT_STREAM_MODE + " does not support snappy");
       case CHECKED:
       default:
         os = new BufferedOutputStream(fos);
@@ -184,8 +180,8 @@ public class SnapStream {
         isValid = isValidGZipStream(file);
         break;
       case SNAPPY:
-        isValid = isValidSnappyStream(file);
-        break;
+        throw new UnsupportedOperationException(
+            "[KYUUBI-SHADED #28] " + ZOOKEEPER_SHAPSHOT_STREAM_MODE + " does not support snappy");
       case CHECKED:
       default:
         isValid = isValidCheckedStream(file);
@@ -252,20 +248,8 @@ public class SnapStream {
    * @throws IOException
    */
   private static boolean isValidSnappyStream(File f) throws IOException {
-    byte[] byteArray = new byte[SnappyCodec.MAGIC_LEN];
-    try (FileInputStream fis = new FileInputStream(f)) {
-      if (SnappyCodec.MAGIC_LEN != fis.read(byteArray, 0, SnappyCodec.MAGIC_LEN)) {
-        LOG.error("Read incorrect number of bytes from {}", f.getName());
-        return false;
-      }
-      ByteBuffer bb = ByteBuffer.wrap(byteArray);
-      byte[] magicHeader = new byte[SnappyCodec.MAGIC_LEN];
-      bb.get(magicHeader, 0, SnappyCodec.MAGIC_LEN);
-      return Arrays.equals(magicHeader, SnappyCodec.getMagicHeader());
-    } catch (FileNotFoundException e) {
-      LOG.error("Unable to open file {}", f.getName(), e);
-      return false;
-    }
+    throw new UnsupportedOperationException(
+        "[KYUUBI-SHADED #28] " + ZOOKEEPER_SHAPSHOT_STREAM_MODE + " does not support snappy");
   }
 
   /**

--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/src/main/resources/META-INF/NOTICE
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/src/main/resources/META-INF/NOTICE
@@ -13,4 +13,3 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.curator:curator-recipes:5.4.0
 - org.apache.zookeeper:zookeeper-jute:3.6.4
 - org.apache.zookeeper:zookeeper:3.6.4
-- org.xerial.snappy:xerial-java:1.1.8.4

--- a/kyuubi-relocated-zookeeper-parent/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/pom.xml
@@ -97,10 +97,6 @@ under the License.
                                     <pattern>com.google</pattern>
                                     <shadedPattern>${shading.prefix}.google</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.xerial.snappy</pattern>
-                                    <shadedPattern>${shading.prefix}.snappy</shadedPattern>
-                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is step 2 of https://github.com/apache/kyuubi-shaded/pull/28

> 2. remove the Snappy support (simply throw `UnsupportedOperationException`) in `org.apache.zookeeper.server.persistence.SnapStream` and snappy deps

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
