### PR TITLE
Move transitve deps of Zookeeper/Curator to sub-package

### DIFF
--- a/kyuubi-relocated-zookeeper-parent/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/pom.xml
@@ -87,7 +87,7 @@ under the License.
                                 </relocation>
                                 <relocation>
                                     <pattern>com.codahale.metrics</pattern>
-                                    <shadedPattern>${shading.prefix}.metrics</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.zookeeper.metrics</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.curator</pattern>
@@ -95,7 +95,7 @@ under the License.
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
-                                    <shadedPattern>${shading.prefix}.google</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.curator.google</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current name pattern does not cause real issues, it's just for safety, i.e. if we create another shaded component that also depends on Guava, the existing `<shadedPattern>${shading.prefix}.google</shadedPattern>` would cause conflicts.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
