### PR TITLE
[KYUUBI-SHADED #33] Step 2/2: Port ZOOKEEPER-1718 to support JLine2 in ZK client 3.4

### DIFF
--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/pom.xml
@@ -36,7 +36,7 @@ under the License.
         <curator.version>2.12.0</curator.version>
         <slf4j.version>1.7.25</slf4j.version>
         <yetus.version>0.5.0</yetus.version>
-        <jline.version>0.9.94</jline.version>
+        <jline.version>2.14.6</jline.version>
     </properties>
 
     <dependencyManagement>

--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/src/main/java/org/apache/zookeeper/JLineZNodeCompleter.java
@@ -19,12 +19,12 @@
 package org.apache.zookeeper;
 
 import java.util.List;
-import jline.Completor;
+import jline.console.completer.Completer;
 
-class JLineZNodeCompletor implements Completor {
+class JLineZNodeCompleter implements Completer {
   private ZooKeeper zk;
 
-  public JLineZNodeCompletor(ZooKeeper zk) {
+  public JLineZNodeCompleter(ZooKeeper zk) {
     this.zk = zk;
   }
 

--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/src/main/java/org/apache/zookeeper/ZooKeeperMain.java
@@ -295,15 +295,16 @@ public class ZooKeeperMain {
       boolean jlinemissing = false;
       // only use jline if it's in the classpath
       try {
-        Class<?> consoleC = Class.forName("jline.ConsoleReader");
-        Class<?> completorC = Class.forName("org.apache.zookeeper.JLineZNodeCompletor");
+        Class<?> consoleC = Class.forName("jline.console.ConsoleReader");
+        Class<?> completorC = Class.forName("org.apache.zookeeper.JLineZNodeCompleter");
 
         System.out.println("JLine support is enabled");
 
         Object console = consoleC.getConstructor().newInstance();
 
         Object completor = completorC.getConstructor(ZooKeeper.class).newInstance(zk);
-        Method addCompletor = consoleC.getMethod("addCompletor", Class.forName("jline.Completor"));
+        Method addCompletor =
+            consoleC.getMethod("addCompleter", Class.forName("jline.console.completer.Completer"));
         addCompletor.invoke(console, completor);
 
         String line;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR aims to port ZOOKEEPER-1718 to make the Zookeeper 3.4 to support JLine2.

To gain a clear change history, I propose to split the change into 2 PRs,

1. copy [org.apache.zookeeper.ZooKeeperMain](https://raw.githubusercontent.com/apache/zookeeper/release-3.4.14/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperMain.java) and [org.apache.zookeeper.JLineZNodeCompletor](https://raw.githubusercontent.com/apache/zookeeper/release-3.4.14/zookeeper-server/src/main/java/org/apache/zookeeper/JLineZNodeCompletor.java) from Apache Zookeeper v3.4.14 as-is
2. apply changes in ZOOKEEPER-1718

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

1. perform `build/mvn clean package` to generate `kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/target/kyuubi-relocated-zookeeper-34-0.3.0-SNAPSHOT.jar`
2. download and install [apache-kyuubi-1.8.0-bin.tgz](https://dlcdn.apache.org/kyuubi/kyuubi-1.8.0/apache-kyuubi-1.8.0-bin.tgz)
3. replace `KYUUBI_HOME/jars/kyuubi-shaded-zookeeper-34-0.1.0.jar` with `kyuubi-relocated-zookeeper-34-0.3.0-SNAPSHOT.jar`
4. replace `KYUUBI_HOME/jars/jline-0.9.94.jar` with `jline-2.14.6.jar`
5. perform `bin/kyuubi-zk-cli -server xxxxx:2181` to connect a Zookeeper cluster
6. check the logs to make sure JLine is enabled and run some command to check basic functionalities
```
...
2024-01-15 19:52:04.593 INFO org.apache.kyuubi.shaded.zookeeper.ZooKeeper: Client environment:java.class.path=...:jline-2.14.6.jar:...:kyuubi-relocated-zookeeper-34-0.3.0-SNAPSHOT.jar...
...
JLine support is enabled
...
```

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
