### PR TITLE
Remove dependencyManagement in shaded zookeeper pom

### DIFF
--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-34/pom.xml
@@ -39,16 +39,6 @@ under the License.
         <jline.version>2.14.6</jline.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -71,6 +61,7 @@ under the License.
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- only required for ZK servers, not clients -->

--- a/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/pom.xml
+++ b/kyuubi-relocated-zookeeper-parent/kyuubi-relocated-zookeeper-36/pom.xml
@@ -38,23 +38,6 @@ under the License.
         <netty.version>4.1.91.Final</netty.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <!-- kyuubi distribution provides logging classes -->
@@ -66,6 +49,7 @@ under the License.
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
             <exclusions>
                 <exclusion>
                     <!-- kyuubi distribution provides logging classes -->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To gain a cleaner `pom.xml`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

Manually tested, and the `dependencyManagement` block is removed after this change.
```
  ...
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.apache.zookeeper</groupId>
        <artifactId>zookeeper</artifactId>
        <version>${zookeeper.version}</version>
      </dependency>
      <dependency>
        <groupId>io.netty</groupId>
        <artifactId>netty-bom</artifactId>
        <version>${netty.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  ...
```

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
