### PR TITLE
Bump Thrift 0.16.0

### DIFF
--- a/kyuubi-relocated-thrift/pom.xml
+++ b/kyuubi-relocated-thrift/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
     <properties>
         <fb303.version>0.9.3</fb303.version>
-        <thrift.version>0.9.3-1</thrift.version>
+        <thrift.version>0.16.0</thrift.version>
     </properties>
 
     <dependencies>

--- a/kyuubi-relocated-thrift/src/main/java/org/apache/thrift/partial/Validate.java
+++ b/kyuubi-relocated-thrift/src/main/java/org/apache/thrift/partial/Validate.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift.partial;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+// THRIFT-5443 (fixed in 0.16.0) pulls Apache Commons Lang3 but only uses in this class,
+// modified to remove dependency of Apache Commons Lang3
+
+/**
+ * A superset of Validate class in Apache Commons Lang3
+ *
+ * <p>It provides consistent message strings for frequently encountered checks. That simplifies
+ * callers because they have to supply only the name of the argument that failed a check instead of
+ * having to supply the entire message.
+ */
+public final class Validate {
+  private Validate() {}
+
+  /** Validates that the given reference argument is not null. */
+  public static void checkNotNull(Object obj, String argName) {
+    checkArgument(obj != null, "'%s' must not be null.", argName);
+  }
+
+  /** Validates that the given integer argument is not zero or negative. */
+  public static void checkPositiveInteger(long value, String argName) {
+    checkArgument(value > 0, "'%s' must be a positive integer.", argName);
+  }
+
+  /** Validates that the given integer argument is not negative. */
+  public static void checkNotNegative(long value, String argName) {
+    checkArgument(value >= 0, "'%s' must not be negative.", argName);
+  }
+
+  /*
+   * Validates that the expression (that checks a required field is present) is true.
+   */
+  public static void checkRequired(boolean isPresent, String argName) {
+    checkArgument(isPresent, "'%s' is required.", argName);
+  }
+
+  /** Validates that the expression (that checks a field is valid) is true. */
+  public static void checkValid(boolean isValid, String argName) {
+    checkArgument(isValid, "'%s' is invalid.", argName);
+  }
+
+  /** Validates that the expression (that checks a field is valid) is true. */
+  public static void checkValid(boolean isValid, String argName, String validValues) {
+    checkArgument(isValid, "'%s' is invalid. Valid values are: %s.", argName, validValues);
+  }
+
+  /** Validates that the given string is not null and has non-zero length. */
+  public static void checkNotNullAndNotEmpty(String arg, String argName) {
+    Validate.checkNotNull(arg, argName);
+    Validate.checkArgument(arg.length() > 0, "'%s' must not be empty.", argName);
+  }
+
+  /** Validates that the given array is not null and has at least one element. */
+  public static <T> void checkNotNullAndNotEmpty(T[] array, String argName) {
+    Validate.checkNotNull(array, argName);
+    checkNotEmpty(array.length, argName);
+  }
+
+  /** Validates that the given array is not null and has at least one element. */
+  public static void checkNotNullAndNotEmpty(byte[] array, String argName) {
+    Validate.checkNotNull(array, argName);
+    checkNotEmpty(array.length, argName);
+  }
+
+  /** Validates that the given array is not null and has at least one element. */
+  public static void checkNotNullAndNotEmpty(short[] array, String argName) {
+    Validate.checkNotNull(array, argName);
+    checkNotEmpty(array.length, argName);
+  }
+
+  /** Validates that the given array is not null and has at least one element. */
+  public static void checkNotNullAndNotEmpty(int[] array, String argName) {
+    Validate.checkNotNull(array, argName);
+    checkNotEmpty(array.length, argName);
+  }
+
+  /** Validates that the given array is not null and has at least one element. */
+  public static void checkNotNullAndNotEmpty(long[] array, String argName) {
+    Validate.checkNotNull(array, argName);
+    checkNotEmpty(array.length, argName);
+  }
+
+  /** Validates that the given buffer is not null and has non-zero capacity. */
+  public static <T> void checkNotNullAndNotEmpty(Iterable<T> iter, String argName) {
+    Validate.checkNotNull(iter, argName);
+    int minNumElements = iter.iterator().hasNext() ? 1 : 0;
+    checkNotEmpty(minNumElements, argName);
+  }
+
+  /** Validates that the given set is not null and has an exact number of items. */
+  public static <T> void checkNotNullAndNumberOfElements(
+      Collection<T> collection, int numElements, String argName) {
+    Validate.checkNotNull(collection, argName);
+    checkArgument(
+        collection.size() == numElements,
+        "Number of elements in '%s' must be exactly %s, %s given.",
+        argName,
+        numElements,
+        collection.size());
+  }
+
+  /** Validates that the given two values are equal. */
+  public static void checkValuesEqual(
+      long value1, String value1Name, long value2, String value2Name) {
+    checkArgument(
+        value1 == value2,
+        "'%s' (%s) must equal '%s' (%s).",
+        value1Name,
+        value1,
+        value2Name,
+        value2);
+  }
+
+  /** Validates that the first value is an integer multiple of the second value. */
+  public static void checkIntegerMultiple(
+      long value1, String value1Name, long value2, String value2Name) {
+    checkArgument(
+        (value1 % value2) == 0,
+        "'%s' (%s) must be an integer multiple of '%s' (%s).",
+        value1Name,
+        value1,
+        value2Name,
+        value2);
+  }
+
+  /** Validates that the first value is greater than the second value. */
+  public static void checkGreater(long value1, String value1Name, long value2, String value2Name) {
+    checkArgument(
+        value1 > value2,
+        "'%s' (%s) must be greater than '%s' (%s).",
+        value1Name,
+        value1,
+        value2Name,
+        value2);
+  }
+
+  /** Validates that the first value is greater than or equal to the second value. */
+  public static void checkGreaterOrEqual(
+      long value1, String value1Name, long value2, String value2Name) {
+    checkArgument(
+        value1 >= value2,
+        "'%s' (%s) must be greater than or equal to '%s' (%s).",
+        value1Name,
+        value1,
+        value2Name,
+        value2);
+  }
+
+  /** Validates that the first value is less than or equal to the second value. */
+  public static void checkLessOrEqual(
+      long value1, String value1Name, long value2, String value2Name) {
+    checkArgument(
+        value1 <= value2,
+        "'%s' (%s) must be less than or equal to '%s' (%s).",
+        value1Name,
+        value1,
+        value2Name,
+        value2);
+  }
+
+  /** Validates that the given value is within the given range of values. */
+  public static void checkWithinRange(
+      long value, String valueName, long minValueInclusive, long maxValueInclusive) {
+    checkArgument(
+        (value >= minValueInclusive) && (value <= maxValueInclusive),
+        "'%s' (%s) must be within the range [%s, %s].",
+        valueName,
+        value,
+        minValueInclusive,
+        maxValueInclusive);
+  }
+
+  /** Validates that the given value is within the given range of values. */
+  public static void checkWithinRange(
+      double value, String valueName, double minValueInclusive, double maxValueInclusive) {
+    checkArgument(
+        (value >= minValueInclusive) && (value <= maxValueInclusive),
+        "'%s' (%s) must be within the range [%s, %s].",
+        valueName,
+        value,
+        minValueInclusive,
+        maxValueInclusive);
+  }
+
+  public static void checkPathExists(Path path, String argName) {
+    checkNotNull(path, argName);
+    checkArgument(Files.exists(path), "Path %s (%s) does not exist.", argName, path);
+  }
+
+  public static void checkPathExistsAsDir(Path path, String argName) {
+    checkPathExists(path, argName);
+    checkArgument(
+        Files.isDirectory(path), "Path %s (%s) must point to a directory.", argName, path);
+  }
+
+  public static void checkPathExistsAsFile(Path path, String argName) {
+    checkPathExists(path, argName);
+    checkArgument(Files.isRegularFile(path), "Path %s (%s) must point to a file.", argName, path);
+  }
+
+  public static void checkArgument(boolean expression, String format, Object... args) {
+    if (!expression) {
+      throw new IllegalArgumentException(getMessage(format, args));
+    }
+  }
+
+  public static void checkState(boolean expression, String format, Object... args) {
+    if (!expression) {
+      throw new IllegalStateException(getMessage(format, args));
+    }
+  }
+
+  private static void checkNotEmpty(int arraySize, String argName) {
+    Validate.checkArgument(arraySize > 0, "'%s' must have at least one element.", argName);
+  }
+
+  private static String getMessage(final String message, final Object... values) {
+    return values == null || values.length == 0 ? message : String.format(message, values);
+  }
+}

--- a/kyuubi-relocated-thrift/src/main/resources/META-INF/NOTICE
+++ b/kyuubi-relocated-thrift/src/main/resources/META-INF/NOTICE
@@ -7,4 +7,4 @@ The Apache Software Foundation (https://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.thrift:libfb303:0.9.3
-- org.apache.thrift:libthrift:0.9.3-1
+- org.apache.thrift:libthrift:0.16.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current Thrift 0.9.3-1 has the following CVEs.

- CVE-2020-13949 - THRIFT-5237(fixed in 0.14.0) - https://github.com/apache/thrift/pull/2191
- CVE-2019-0205 - THRIFT-4053(fixed in 0.11.0) - https://github.com/apache/thrift/pull/1371
- CVE-2018-11798 - only affects NodeJS

We choose to upgrade 0.16.0 because
- has no CVEs reported yet
- the latest Hive 4.0.0-beta1 uses Thrift 0.16.0
- Thrift 0.17.0 ~ 0.18.1 has issues on transitive deps
- Thrift 0.18.0 is built on Java 11, which is not compatible with Java 8
- Thrift 0.19.0 restores support for Java 8, but upgrades Apache Http Client5, it involves additional deps

Also, this PR overrides one class `org.apache.thrift.partial.Validate` to remove dependency of Apache Commons Lang3

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request
