### PR TITLE
[INFRA] Disable GitHub Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,7 +27,7 @@ github:
   protected_branches: ~
   features:
     issues: true
-    discussions: true
+    discussions: false
     wiki: false
     projects: false
 notifications:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Centralize discussions to the [main repo](https://github.com/apache/kyuubi)

> An error occurred while processing the github feature in .asf.yaml:
>
> GitHub discussions can only be enabled if a mailing list target exists for it.

### _How was this patch tested?_

Manual check after merging.
