### PR TITLE
Correct fix_title in dev/merge_kyuubi_pr.py

### DIFF
--- a/dev/merge_kyuubi_pr.py
+++ b/dev/merge_kyuubi_pr.py
@@ -90,7 +90,7 @@ def clean_up():
             run_cmd("git branch -D %s" % branch)
 
 def fix_title(text, num):
-    if (re.search(r'^\[KYUUBI\s#[0-9]{3,6}\].*', text)):
+    if (re.search(r'^\[KYUUBI(-SHADED)?\s#[0-9]{2,6}\].*', text)):
         return text
 
     return '[KYUUBI-SHADED #%s] %s' % (num, text)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make it also recognize PR title prefix like `[KYUUBI-SHADED #60]`

### _How was this patch tested?_
Before
```
fix_title("[KYUUBI-SHADED #60] Step 1/2: Copy TSaslServerTransport from Thrift 0.16.0", 62)
'[KYUUBI-SHADED #62][KYUUBI-SHADED #60] Step 1/2: Copy TSaslServerTransport from Thrift 0.16.0'
```
After
```
>>> fix_title("[KYUUBI-SHADED #60] Step 1/2: Copy TSaslServerTransport from Thrift 0.16.0", 62)
'[KYUUBI-SHADED #60] Step 1/2: Copy TSaslServerTransport from Thrift 0.16.0'
```
