### PR TITLE
New util module wraps sun.misc.Signal

### DIFF
--- a/kyuubi-relocated-util/pom.xml
+++ b/kyuubi-relocated-util/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.kyuubi</groupId>
+        <artifactId>kyuubi-relocated-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kyuubi-relocated-util</artifactId>
+    <description>Utility classes used by Kyuubi internally.</description>
+
+    <properties>
+        <slf4j.version>1.7.36</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kyuubi-relocated-util/src/main/java/org/apache/kyuubi/shaded/util/Signal.java
+++ b/kyuubi-relocated-util/src/main/java/org/apache/kyuubi/shaded/util/Signal.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.shaded.util;
+
+public final class Signal {
+
+  // Delegate to sun.misc.Signal.
+  private final sun.misc.Signal iSignal;
+
+  /* Returns the signal number */
+  public int getNumber() {
+    return iSignal.getNumber();
+  }
+
+  /**
+   * Returns the signal name.
+   *
+   * @return the name of the signal.
+   * @see sun.misc.Signal#Signal(String name)
+   */
+  public String getName() {
+    return iSignal.getName();
+  }
+
+  /**
+   * Compares the equality of two <code>Signal</code> objects.
+   *
+   * @param other the object to compare with.
+   * @return whether two <code>Signal</code> objects are equal.
+   */
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || !(other instanceof Signal)) {
+      return false;
+    }
+    Signal other1 = (Signal) other;
+    return iSignal.equals(other1.iSignal);
+  }
+
+  /**
+   * Returns a hashcode for this Signal.
+   *
+   * @return a hash code value for this object.
+   */
+  public int hashCode() {
+    return getNumber();
+  }
+
+  /**
+   * Returns a string representation of this signal. For example, "SIGINT" for an object constructed
+   * using <code>new Signal ("INT")</code>.
+   *
+   * @return a string representation of the signal
+   */
+  public String toString() {
+    return iSignal.toString();
+  }
+
+  /**
+   * Constructs a signal from its name.
+   *
+   * @param name the name of the signal.
+   * @exception IllegalArgumentException unknown signal
+   * @see sun.misc.Signal#getName()
+   */
+  public Signal(String name) {
+    iSignal = new sun.misc.Signal(name);
+  }
+
+  /**
+   * Registers a signal handler.
+   *
+   * @param sig a signal
+   * @param handler the handler to be registered with the given signal.
+   * @return the old handler
+   * @exception IllegalArgumentException the signal is in use by the VM
+   * @see sun.misc.Signal#raise(sun.misc.Signal sig)
+   * @see sun.misc.SignalHandler
+   * @see sun.misc.SignalHandler#SIG_DFL
+   * @see sun.misc.SignalHandler#SIG_IGN
+   */
+  public static synchronized SignalHandler handle(Signal sig, SignalHandler handler)
+      throws IllegalArgumentException {
+    sun.misc.SignalHandler oldHandler =
+        sun.misc.Signal.handle(sig.iSignal, SunMiscHandler.of(sig, handler));
+    return KyuubiSignalHandler.of(sig.iSignal, oldHandler);
+  }
+
+  /**
+   * Raises a signal in the current process.
+   *
+   * @param sig a signal
+   * @see sun.misc.Signal#handle(sun.misc.Signal sig, sun.misc.SignalHandler handler)
+   */
+  public static void raise(Signal sig) throws IllegalArgumentException {
+    sun.misc.Signal.raise(sig.iSignal);
+  }
+
+  /*
+   * Wrapper class to proxy a SignalHandler to a sun.misc.SignalHandler.
+   */
+  static final class SunMiscHandler implements sun.misc.SignalHandler {
+    private final SignalHandler handler;
+    private final Signal signal;
+
+    static sun.misc.SignalHandler of(Signal signal, SignalHandler handler) {
+      if (handler == SignalHandler.SIG_DFL) {
+        return sun.misc.SignalHandler.SIG_DFL;
+      } else if (handler == SignalHandler.SIG_IGN) {
+        return sun.misc.SignalHandler.SIG_IGN;
+      } else if (handler instanceof KyuubiSignalHandler) {
+        return ((KyuubiSignalHandler) handler).iHandler;
+      } else {
+        return new SunMiscHandler(signal, handler);
+      }
+    }
+
+    private SunMiscHandler(Signal signal, SignalHandler handler) {
+      this.handler = handler;
+      this.signal = signal;
+    }
+
+    @Override
+    public void handle(sun.misc.Signal ignore) {
+      handler.handle(signal);
+    }
+  }
+
+  /*
+   * Wrapper class to proxy a sun.misc.SignalHandler to a SignalHandler.
+   */
+  static final class KyuubiSignalHandler implements SignalHandler {
+    private final sun.misc.Signal iSignal;
+    private final sun.misc.SignalHandler iHandler;
+
+    static SignalHandler of(sun.misc.Signal signal, sun.misc.SignalHandler handler) {
+      if (handler == sun.misc.SignalHandler.SIG_DFL) {
+        return SignalHandler.SIG_DFL;
+      } else if (handler == sun.misc.SignalHandler.SIG_IGN) {
+        return SignalHandler.SIG_IGN;
+      } else if (handler instanceof SunMiscHandler) {
+        return ((SunMiscHandler) handler).handler;
+      } else {
+        return new KyuubiSignalHandler(signal, handler);
+      }
+    }
+
+    KyuubiSignalHandler(sun.misc.Signal iSignal, sun.misc.SignalHandler iHandler) {
+      this.iSignal = iSignal;
+      this.iHandler = iHandler;
+    }
+
+    @Override
+    public void handle(Signal sig) {
+      iHandler.handle(iSignal);
+    }
+
+    public String toString() {
+      return iHandler.toString();
+    }
+  }
+}

--- a/kyuubi-relocated-util/src/main/java/org/apache/kyuubi/shaded/util/SignalHandler.java
+++ b/kyuubi-relocated-util/src/main/java/org/apache/kyuubi/shaded/util/SignalHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kyuubi.shaded.util;
+
+/** This is the signal handler interface expected in <code>Signal.handle</code>. */
+public interface SignalHandler {
+
+  /** The default signal handler */
+  SignalHandler SIG_DFL = new Signal.KyuubiSignalHandler(null, sun.misc.SignalHandler.SIG_DFL);
+  /** Ignore the signal */
+  SignalHandler SIG_IGN = new Signal.KyuubiSignalHandler(null, sun.misc.SignalHandler.SIG_IGN);
+
+  /**
+   * Handle the given signal
+   *
+   * @param sig a signal object
+   */
+  void handle(Signal sig);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>kyuubi-relocated-hive-service-rpc</module>
         <module>kyuubi-relocated-spark-connect-rpc</module>
         <module>kyuubi-relocated-thrift</module>
+        <module>kyuubi-relocated-util</module>
         <module>kyuubi-relocated-zookeeper-parent</module>
     </modules>
 
@@ -361,12 +362,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.googlecode.maven-download-plugin</groupId>
-                    <artifactId>download-maven-plugin</artifactId>
-                    <version>${maven.plugin.download.version}</version>
-                </plugin>
-
-                <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
                     <inherited>true</inherited>
@@ -470,16 +465,6 @@
 
     <profiles>
         <profile>
-            <id>java-8</id>
-            <activation>
-                <jdk>8</jdk>
-            </activation>
-            <properties>
-                <java.version>8</java.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>apache-release</id>
             <build>
                 <plugins>
@@ -553,6 +538,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <!-- Make Java 9+ happy, release is not affected since it uses Java 8. -->
+                <maven.compiler.release></maven.compiler.release>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI-SHADED #XXXX]' in your PR title, e.g., '[KYUUBI-SHADED #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI-SHADED #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To allow Kyuubi to compile with `-release:8` in JDK 9+, we must cut off direct access `sun.misc.Signal`, this PR achieves it by creating wrapper classes of `sun.misc.Signal` and `sun.misc.SignalHandler` in the Kyuubi Shaded project.

Currently, both Kyuubi and Kyuubi Shaded use Java 8 for release. After this change, Kyuubi can use any of Java 8+ to compile with `-release:8` while still ensuring compatibility with Java 8.

### _How was this patch tested?_

Have done a PoC - modify Kyuubi code to use the wrapper Signal classes, and compile with JDK 21, run on JDK 8, everything works as expected.
